### PR TITLE
Add severity_border config option (+ themeable border width)

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,23 @@ When enabled:
 
 All 50 visual themes retain their animations and layouts — only the color palette adapts. Compatible with Mushroom, Material, iOS, and any custom HA theme.
 
+### Severity border
+
+Each alert block also gets a 1px border in its severity color (critical/warning/info/OK), separate from the badge/text colors above. Turn it off per-card while keeping the color-coded badges and icons:
+
+```yaml
+severity_border: false
+```
+
+Default: `true` (on) — existing dashboards are unaffected. The border width is also exposed as the `--atc-severity-border-width` CSS custom property (default `1px`) if you'd rather control it theme-wide instead of per-card:
+
+```yaml
+your-theme-name:
+  atc-severity-border-width: "0px"
+```
+
+`severity_border: false` on the card always wins over the theme variable.
+
 ### Card border
 
 Enable a persistent visible border around the card using the standard HA border style:
@@ -1164,6 +1181,7 @@ The tab shows an **ON** badge when overlay mode is active.
 | `active_state_entity` | `string` | — | **Per-alert.** `input_boolean.*` entity to write `on`/`off` to when this specific alert becomes active or clears. Each alert can target a different boolean. Works only while the browser tab is open. |
 | `card_height` | `number` | *(auto)* | Fixed card height in px — prevents layout shifts when cycling |
 | `card_border` | `boolean` | `false` | Show the standard HA border around the card at all times |
+| `severity_border` | `boolean` | `true` | Show the 1px severity-colored border around each alert block. Set `false` to keep badge/icon color coding without the border. Width themeable via `--atc-severity-border-width`. |
 | `overlay_mode` | `boolean` | `false` | Show a floating banner when a new alert triggers — visible from any dashboard view |
 | `overlay_position` | `string` | `top` | Banner position: `top`, `center`, or `bottom` |
 | `overlay_duration` | `number` | `8` | Seconds before auto-dismiss (0 = manual close only) |

--- a/alert-ticker-card-editor.js
+++ b/alert-ticker-card-editor.js
@@ -1242,6 +1242,8 @@ const ET = {
     card_height_help: "Locks the height to prevent layout shifts when alerts change. Leave empty for automatic height.",
     card_border: "Show card border & name",
     card_border_help: "Adds the standard Home Assistant border around the card. When no alerts are active, shows a placeholder with the card name instead of hiding completely.",
+    severity_border: "Show severity border",
+    severity_border_help: "Draws a 1px colored border around each alert matching its severity (critical/warning/info/OK). Turn off to keep badge/icon color coding without the border. Width is themeable via --atc-severity-border-width.",
     card_background: "Custom background / transparency",
     card_background_help: "Enable to use the HA theme variable (--ha-card-background). Enter a custom CSS value to use a fixed color, e.g. rgba(0,0,0,0.5).",
     show_snooze_bar: "Show snooze reactivation bar 💤",
@@ -5616,6 +5618,16 @@ class AlertTickerCardEditor extends LitElement {
           ></ha-switch>
         </div>
         <div class="helper-text">${this._t("card_border_help")}</div>
+      </div>
+      <div class="form-row">
+        <div class="toggle-row">
+          <span>${this._t("severity_border")}</span>
+          <ha-switch
+            .checked="${cfg.severity_border !== false}"
+            @change="${(e) => this._fireConfig({ ...this._config, severity_border: e.target.checked ? undefined : false })}"
+          ></ha-switch>
+        </div>
+        <div class="helper-text">${this._t("severity_border_help")}</div>
       </div>
       <div class="form-row">
         <div class="toggle-row">

--- a/alert-ticker-card.js
+++ b/alert-ticker-card.js
@@ -4392,6 +4392,7 @@ class AlertTickerCard extends LitElement {
     this.style.setProperty("--atc-card-outline", this._config?.card_border
       ? "1px solid var(--ha-card-border-color, var(--divider-color, rgba(255,255,255,0.25)))"
       : "var(--ha-card-border-width, 0px) solid var(--ha-card-border-color, transparent)");
+    this.style.setProperty("--atc-severity-border-width", this._config?.severity_border === false ? "0px" : "");
     const bg = this._config?.card_background;
     if (bg && bg !== false) {
       let bgValue;
@@ -10242,7 +10243,7 @@ class AlertTickerCard extends LitElement {
       .atc-ha-theme .at-motion,
       .atc-ha-theme .at-intruder,
       .atc-ha-theme .at-toxic {
-        border: 1px solid var(--error-color, #e53935) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--error-color, #e53935) !important;
       }
       .atc-ha-theme .at-emergency [class$="-badge"],
       .atc-ha-theme .at-alarm     [class$="-badge"],
@@ -10266,7 +10267,7 @@ class AlertTickerCard extends LitElement {
       .atc-ha-theme .at-smoke,
       .atc-ha-theme .at-wind,
       .atc-ha-theme .at-leak {
-        border: 1px solid var(--warning-color, #ff9800) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--warning-color, #ff9800) !important;
       }
       .atc-ha-theme .at-warning     [class$="-badge"],
       .atc-ha-theme .at-caution     [class$="-badge"],
@@ -10301,7 +10302,7 @@ class AlertTickerCard extends LitElement {
       .atc-ha-theme .at-cyberpunk,
       .atc-ha-theme .at-vapor,
       .atc-ha-theme .at-ticker {
-        border: 1px solid var(--info-color, var(--primary-color, #2196f3)) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--info-color, var(--primary-color, #2196f3)) !important;
       }
       .atc-ha-theme .at-info         [class$="-badge"],
       .atc-ha-theme .at-notification [class$="-badge"],
@@ -10335,7 +10336,7 @@ class AlertTickerCard extends LitElement {
       .atc-ha-theme .at-sunrise,
       .atc-ha-theme .at-plant,
       .atc-ha-theme .at-lock {
-        border: 1px solid var(--success-color, #43a047) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--success-color, #43a047) !important;
       }
       .atc-ha-theme .at-success  [class$="-badge"],
       .atc-ha-theme .at-check    [class$="-badge"],
@@ -10351,7 +10352,7 @@ class AlertTickerCard extends LitElement {
       /* ── 3D Spectacular — critical ── */
       .atc-ha-theme .at-portal,
       .atc-ha-theme .at-void {
-        border: 1px solid var(--error-color, #f44336) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--error-color, #f44336) !important;
       }
       .atc-ha-theme .at-portal [class$="-badge"],
       .atc-ha-theme .at-void   [class$="-badge"] {
@@ -10366,7 +10367,7 @@ class AlertTickerCard extends LitElement {
       /* ── 3D Spectacular — warning ── */
       .atc-ha-theme .at-volt,
       .atc-ha-theme .at-nebula {
-        border: 1px solid var(--warning-color, #ff9800) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--warning-color, #ff9800) !important;
       }
       .atc-ha-theme .at-volt   [class$="-badge"],
       .atc-ha-theme .at-nebula [class$="-badge"] {
@@ -10379,7 +10380,7 @@ class AlertTickerCard extends LitElement {
       /* ── 3D Spectacular — info ── */
       .atc-ha-theme .at-prism,
       .atc-ha-theme .at-arcade {
-        border: 1px solid var(--info-color, var(--primary-color, #2196f3)) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--info-color, var(--primary-color, #2196f3)) !important;
       }
       .atc-ha-theme .at-prism  [class$="-badge"] {
         background: var(--info-color, var(--primary-color, #2196f3)) !important;
@@ -10396,7 +10397,7 @@ class AlertTickerCard extends LitElement {
       /* ── 3D Spectacular — ok ── */
       .atc-ha-theme .at-diamond,
       .atc-ha-theme .at-quantum {
-        border: 1px solid var(--success-color, #43a047) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--success-color, #43a047) !important;
       }
       .atc-ha-theme .at-diamond [class$="-badge"],
       .atc-ha-theme .at-quantum [class$="-badge"] {
@@ -10413,7 +10414,7 @@ class AlertTickerCard extends LitElement {
       .atc-ha-theme .at-timer-pulse,
       .atc-ha-theme .at-timer-ring {
         background: var(--card-background-color, #1c1c2e) !important;
-        border: 1px solid var(--divider-color, rgba(0,0,0,0.12)) !important;
+        border: var(--atc-severity-border-width, 1px) solid var(--divider-color, rgba(0,0,0,0.12)) !important;
       }
 
       /* ── Decorative elements reset ── */


### PR DESCRIPTION
## Summary
- The 1px severity border drawn around each alert block (`.atc-ha-theme .at-<severity>`) was hardcoded with `!important` and had no config option to disable, and shared its color variable with the badge/icon text — so there was no way to turn off just the border without also losing severity color coding.
- Adds a new per-card `severity_border: false` option (default `true`, so existing dashboards are unaffected), wired the same way as the existing `card_border` toggle and exposed in the visual editor.
- Underlying border-width is driven by a new `--atc-severity-border-width` CSS custom property (default `1px`), for users who'd rather set it theme-wide instead of per-card. `severity_border: false` on the card always wins over the theme variable.

## Changes
- `alert-ticker-card.js`: all 9 `border: 1px solid var(--*-color...) !important` declarations now read `border: var(--atc-severity-border-width, 1px) solid var(--*-color...) !important`; the existing `card_border` style block now also sets `--atc-severity-border-width` from `this._config?.severity_border`.
- `alert-ticker-card-editor.js`: new toggle-row for `severity_border` next to `card_border`, with English translation strings (`_t()` falls back to English for other locales, so no other locale files needed touching).
- `README.md`: new "Severity border" section + config table row.

## Test plan
- [x] Verified live: `severity_border: false`-equivalent behavior tested against an installed copy — border disappears, badge/icon severity colors unchanged.
- [x] Confirmed default (`severity_border` unset) renders identically to current behavior.
- [ ] Maintainer smoke test in the visual editor and across the theme gallery mentioned in the README.

Rebased onto current `main` (was previously conflicting due to upstream's v1.3.9.9.2/.3 releases landing after this branch was opened).